### PR TITLE
fix(hooks): apply resource-level hooks even to suffixed responders (#…

### DIFF
--- a/docs/api/hooks.rst
+++ b/docs/api/hooks.rst
@@ -39,6 +39,15 @@ decorate the resource class:
         def on_get(self, req, resp, project_id):
             pass
 
+.. note::
+    When decorating an entire resource class, all method names that resemble
+    responders, including *suffix*\ed (see also :meth:`~falcon.API.add_route`)
+    ones, are decorated. If, for instance, a method is called ``on_get_items``,
+    but it is not meant for handling ``GET`` requests under a route with the
+    *suffix* ``items``, the easiest workaround for preventing the hook function
+    from being applied to the method is renaming it not to clash with the
+    responder pattern.
+
 Note also that you can pass additional arguments to your hook function
 as needed:
 

--- a/falcon/api.py
+++ b/falcon/api.py
@@ -584,10 +584,10 @@ class API(object):
             req: The request object.
 
         Returns:
-            tuple: A 3-member tuple consisting of a responder callable,
+            tuple: A 4-member tuple consisting of a responder callable,
             a ``dict`` containing parsed path fields (if any were specified in
-            the matching route's URI template), and a reference to the
-            responder's resource instance.
+            the matching route's URI template), a reference to the responder's
+            resource instance, and the matching URI template.
 
         Note:
             If a responder was matched to the given URI, but the HTTP

--- a/falcon/hooks.py
+++ b/falcon/hooks.py
@@ -15,11 +15,17 @@
 """Hook decorators."""
 
 from functools import wraps
+from inspect import getmembers
+import re
 
 import six
 
 from falcon import COMBINED_METHODS
 from falcon.util.misc import get_argnames
+
+
+_DECORABLE_METHOD_NAME = re.compile(r'^on_({})(_\w+)?$'.format(
+    '|'.join(method.lower() for method in COMBINED_METHODS)))
 
 
 def before(action, *args, **kwargs):
@@ -57,28 +63,18 @@ def before(action, *args, **kwargs):
         if isinstance(responder_or_resource, six.class_types):
             resource = responder_or_resource
 
-            for method in COMBINED_METHODS:
-                responder_name = 'on_' + method.lower()
+            for responder_name, responder in getmembers(resource, callable):
+                if _DECORABLE_METHOD_NAME.match(responder_name):
+                    # This pattern is necessary to capture the current value of
+                    # responder in the do_before_all closure; otherwise, they
+                    # will capture the same responder variable that is shared
+                    # between iterations of the for loop, above.
+                    def let(responder=responder):
+                        do_before_all = _wrap_with_before(responder, action, args, kwargs)
 
-                try:
-                    responder = getattr(resource, responder_name)
-                except AttributeError:
-                    # resource does not implement this method
-                    pass
-                else:
-                    # Usually expect a method, but any callable will do
-                    if callable(responder):
-                        # This pattern is necessary to capture the current
-                        # value of responder in the do_before_all closure;
-                        # otherwise, they will capture the same responder
-                        # variable that is shared between iterations of the
-                        # for loop, above.
-                        def let(responder=responder):
-                            do_before_all = _wrap_with_before(responder, action, args, kwargs)
+                        setattr(resource, responder_name, do_before_all)
 
-                            setattr(resource, responder_name, do_before_all)
-
-                        let()
+                    let()
 
             return resource
 
@@ -112,24 +108,14 @@ def after(action, *args, **kwargs):
         if isinstance(responder_or_resource, six.class_types):
             resource = responder_or_resource
 
-            for method in COMBINED_METHODS:
-                responder_name = 'on_' + method.lower()
+            for responder_name, responder in getmembers(resource, callable):
+                if _DECORABLE_METHOD_NAME.match(responder_name):
+                    def let(responder=responder):
+                        do_after_all = _wrap_with_after(responder, action, args, kwargs)
 
-                try:
-                    responder = getattr(resource, responder_name)
-                except AttributeError:
-                    # resource does not implement this method
-                    pass
-                else:
-                    # Usually expect a method, but any callable will do
-                    if callable(responder):
+                        setattr(resource, responder_name, do_after_all)
 
-                        def let(responder=responder):
-                            do_after_all = _wrap_with_after(responder, action, args, kwargs)
-
-                            setattr(resource, responder_name, do_after_all)
-
-                        let()
+                    let()
 
             return resource
 
@@ -154,7 +140,7 @@ def _wrap_with_after(responder, action, action_args, action_kwargs):
         responder: The responder method to wrap.
         action: A function with a signature similar to a resource responder
             method, taking the form ``func(req, resp, resource)``.
-        action_args: Additiona positional agruments to pass to *action*.
+        action_args: Additional positional agruments to pass to *action*.
         action_kwargs: Additional keyword arguments to pass to *action*.
     """
 
@@ -191,7 +177,7 @@ def _wrap_with_before(responder, action, action_args, action_kwargs):
         responder: The responder method to wrap.
         action: A function with a similar signature to a resource responder
             method, taking the form ``func(req, resp, resource, params)``.
-        action_args: Additiona positional agruments to pass to *action*.
+        action_args: Additional positional agruments to pass to *action*.
         action_kwargs: Additional keyword arguments to pass to *action*.
     """
 

--- a/tests/test_after_hooks.py
+++ b/tests/test_after_hooks.py
@@ -303,3 +303,81 @@ def test_wrapped_resource_with_hooks_aware_of_resource(client, wrapped_resource_
     result = client.simulate_options('/wrapped_aware')
     assert result.status_code == 200
     assert not result.text
+
+
+class ResourceAwareGameHook(object):
+
+    VALUES = ('rock', 'scissors', 'paper')
+
+    @classmethod
+    def __call__(cls, req, resp, resource):
+        assert resource
+        assert resource.seed in cls.VALUES
+        assert resp.text == 'Responder called.'
+
+        header = resp.get_header('X-Hook-Game')
+        values = header.split(', ') if header else []
+        if values:
+            last = cls.VALUES.index(values[-1])
+            values.append(cls.VALUES[(last + 1) % len(cls.VALUES)])
+        else:
+            values.append(resource.seed)
+        resp.set_header('X-Hook-Game', ', '.join(values))
+
+
+_game_hook = ResourceAwareGameHook()
+
+
+@falcon.after(_game_hook)
+@falcon.after(_game_hook)
+class HandGame(object):
+
+    def __init__(self):
+        self.seed = None
+
+    @falcon.after(_game_hook)
+    def on_put(self, req, resp):
+        self.seed = req.media
+        resp.text = 'Responder called.'
+
+    @falcon.after(_game_hook)
+    def on_get_once(self, req, resp):
+        resp.text = 'Responder called.'
+
+    @falcon.after(_game_hook)
+    @falcon.after(_game_hook)
+    def on_get_twice(self, req, resp):
+        resp.text = 'Responder called.'
+
+    @falcon.after(_game_hook)
+    @falcon.after(_game_hook)
+    @falcon.after(_game_hook)
+    def on_get_thrice(self, req, resp):
+        resp.text = 'Responder called.'
+
+
+@pytest.fixture
+def game_client():
+    app = falcon.API()
+    resource = HandGame()
+
+    app.add_route('/seed', resource)
+    app.add_route('/once', resource, suffix='once')
+    app.add_route('/twice', resource, suffix='twice')
+    app.add_route('/thrice', resource, suffix='thrice')
+
+    return testing.TestClient(app)
+
+
+@pytest.mark.parametrize('seed,uri,expected', [
+    ('paper', '/once', 'paper, rock, scissors'),
+    ('scissors', '/twice', 'scissors, paper, rock, scissors'),
+    ('rock', '/thrice', 'rock, scissors, paper, rock, scissors'),
+    ('paper', '/thrice', 'paper, rock, scissors, paper, rock'),
+])
+def test_after_hooks_on_suffixed_resource(game_client, seed, uri, expected):
+    game_client.simulate_put('/seed', json=seed)
+
+    resp = game_client.simulate_get(uri)
+    assert resp.status_code == 200
+    assert resp.headers['X-Hook-Game'] == expected


### PR DESCRIPTION
…1402)

* fix(hooks): apply resource-level hooks even to suffixed responders

Co-authored-by: Mathias Chevalier <mc.mumrau@gmail.com>

* documentation touch-ups: add a note about hook decoration scope

Co-authored-by: Mathias Chevalier <mc.mumrau@gmail.com>